### PR TITLE
feature : WebSecurityConfig 설정 및 authorizeRequests 테스트 코드 작성

### DIFF
--- a/src/main/java/com/dkkim/springsecurity/security/WebSecurityConfig.java
+++ b/src/main/java/com/dkkim/springsecurity/security/WebSecurityConfig.java
@@ -1,0 +1,75 @@
+package com.dkkim.springsecurity.security;
+
+import com.dkkim.springsecurity.security.handler.CustomAccessDeniedHandler;
+import com.dkkim.springsecurity.security.handler.CustomAuthenticationEntryPoint;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+// WebSecurityConfigurerAdapter가 deprecated되어, Lambda DSL로 구성
+@Configuration
+@RequiredArgsConstructor
+public class WebSecurityConfig {
+
+    private static final String[] AUTH_EXCLUDE_LIST = {"/api/health-check"};
+
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
+    @Bean
+    protected SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                // Token을 사용하는 Rest API 서버에서는 csrf를 사용하지 않음
+                .csrf().disable()
+                // form login 사용하지 않음
+                .httpBasic().disable()
+                .logout().disable()
+
+                // 세션을 사용하지 않음
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+
+                // cors config 등록
+                .cors().configurationSource(corsConfigurationSource())
+                .and()
+
+                // 인증 없이 허용할 url
+                .authorizeRequests()
+                .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+                .antMatchers(AUTH_EXCLUDE_LIST).permitAll()
+                .anyRequest().authenticated()
+                .and()
+
+                // Custom Handler 등록
+                .exceptionHandling()
+                .accessDeniedHandler(customAccessDeniedHandler)
+                .authenticationEntryPoint(customAuthenticationEntryPoint)
+                .and()
+        ;
+
+        return http.build();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin("*");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/dkkim/springsecurity/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/dkkim/springsecurity/security/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,19 @@
+package com.dkkim.springsecurity.security.handler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+    }
+}

--- a/src/main/java/com/dkkim/springsecurity/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/dkkim/springsecurity/security/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,19 @@
+package com.dkkim.springsecurity.security.handler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+    }
+}

--- a/src/main/java/com/dkkim/springsecurity/web/common/HealthCheckController.java
+++ b/src/main/java/com/dkkim/springsecurity/web/common/HealthCheckController.java
@@ -1,0 +1,17 @@
+package com.dkkim.springsecurity.web.common;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class HealthCheckController {
+
+    @GetMapping("/health-check")
+    public ResponseEntity healthCheck() {
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/test/java/com/dkkim/springsecurity/web/HealthCheckControllerTest.java
+++ b/src/test/java/com/dkkim/springsecurity/web/HealthCheckControllerTest.java
@@ -1,0 +1,36 @@
+package com.dkkim.springsecurity.web;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class HealthCheckControllerTest {
+
+    @Autowired
+    MockMvc mvc;
+
+    @Test
+    @DisplayName("antMatchers 등록된 API 인증 없이 성공")
+    void success_antMatchers_api_healthCheck() throws Exception {
+        // when && then
+        mvc.perform(get("/api/health-check"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("antMatchers 등록되지 않은 API 인증 없이 실패")
+    void fail_not_antMatchers_api() throws Exception {
+        // when && then
+        mvc.perform(get("/api/not-authorization-api"))
+                .andExpect(status().isUnauthorized());
+    }
+
+}


### PR DESCRIPTION
Resolves: #4

## Issue
- #4

## Details
- WebSecurityConfigurerAdapter가 deprecated되어 lambda DSL로 spring security 구성

## References
- [Spring Security without the WebSecurityConfigurerAdapter](https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)
- [Spring Security - Lambda DSL](https://spring.io/blog/2019/11/21/spring-security-lambda-dsl)

## Merge Branch
- develop